### PR TITLE
bump rust to 1.64

### DIFF
--- a/containers/ferris_ci_build_x86_64-pc-windows-msvc
+++ b/containers/ferris_ci_build_x86_64-pc-windows-msvc
@@ -3,7 +3,7 @@ FROM centos:centos7
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.63.0 \
+    RUST_VERSION=1.64.0 \
     CC=clang \
     CXX=clang++ \
     AR=llvm-ar

--- a/containers/ferris_ci_build_x86_64-unknown-linux-gnu
+++ b/containers/ferris_ci_build_x86_64-unknown-linux-gnu
@@ -3,7 +3,7 @@ FROM centos:centos7
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.63.0 \
+    RUST_VERSION=1.64.0 \
     CC=clang \
     CXX=clang++ \
     AR=llvm-ar

--- a/containers/ferris_ci_clippy
+++ b/containers/ferris_ci_clippy
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.63.0
+    RUST_VERSION=1.64.0
 
 COPY ferris-ci /usr/bin/ferris-ci
 COPY containers/scripts/setup_clippy.sh /scripts/

--- a/containers/scripts/setup_vendor.sh
+++ b/containers/scripts/setup_vendor.sh
@@ -6,7 +6,6 @@ apt-get update
 apt-get install -y --no-install-recommends \
 		ca-certificates \
 		gzip \
-		openssh-client \
 		tar  \
 		curl
 rm -rf /var/lib/apt/lists/*
@@ -23,6 +22,6 @@ mv /GIT/libexec/git-core/* /usr/libexec/git-core/
 rm -rf /GIT
 
 # Install cargo
-VERSION="0.64.0"
+VERSION="1.64.0"
 URL="https://openva.fra1.cdn.digitaloceanspaces.com/cargo-${VERSION}.tar.gz"
 ferris-ci install-tool cargo $URL

--- a/scripts/build_cargo.sh
+++ b/scripts/build_cargo.sh
@@ -21,21 +21,19 @@ fi
 
 
 build_dir="cargo_src"
-VERSION="0.64.0"
-BRANCH="${VERSION}"
+VERSION="1.64.0"
+BRANCH="rust-${VERSION}"
 URL=https://github.com/rust-lang/cargo.git
 
 git clone --depth 1 --single-branch --branch "${BRANCH}" "${URL}" "${build_dir}"
 
 $docker run -v "$(pwd):/io:Z" --entrypoint /bin/bash rust -c "
-apt-get update && \
-apt-get install libssl-dev && \
 cd /io/${build_dir} && \
 CARGO_PROFILE_RELEASE_OPT_LEVEL=z \
 CARGO_PROFILE_RELEASE_PANIC=abort \
 CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
 RUSTC_FLAGS=\"-C strip\" \
-cargo build --release --bin cargo"
+cargo build --release --bin cargo --features=vendored-openssl"
 
 mv $build_dir/target/release/cargo ./cargo
 rm -rf $build_dir

--- a/scripts/build_clippy.sh
+++ b/scripts/build_clippy.sh
@@ -21,7 +21,7 @@ fi
 
 
 build_dir="clippy_src"
-VERSION="1.63.0"
+VERSION="1.64.0"
 BRANCH="rust-${VERSION}"
 URL=https://github.com/rust-lang/rust-clippy.git
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -26,8 +26,8 @@ function build_squashed_image(){
     $docker build --tag "${1}:latest" --squash-all -f "containers/${1}" .
 }
 
-build_squashed_image ferris_ci_build
-build_squashed_image ferris_ci_build_win
+build_squashed_image ferris_ci_build_x86_64-unknown-linux-gnu
+build_squashed_image ferris_ci_build_win_x86_64-pc-windows-msvc
 build_image ferris_ci_clippy
 build_image ferris_ci_dep
 build_image ferris_ci_fmt


### PR DESCRIPTION
- feat: switch to multiple split docker images
- update CI to build seperate images
- update rust
