### PR TITLE
always provide llvm-dlltool

### DIFF
--- a/containers/scripts/setup_builder.sh
+++ b/containers/scripts/setup_builder.sh
@@ -66,6 +66,7 @@ if [[ -n "${CROSS_TARGET:-}" ]]; then
 	ferris-ci download "llvm-${VERSION}-${CROSS_TARGET}-OFF.tar.zst" --decompress
     mv /LLVM/bin/llvm-config* /usr/bin/
 fi
+ln -s llvm-ar /usr/bin/llvm-dlltool
 mv /LLVM/lib64/* /usr/lib64/
 mv /LLVM/include/* /usr/include/
 rm -rf /LLVM

--- a/containers/scripts/setup_win.sh
+++ b/containers/scripts/setup_win.sh
@@ -23,5 +23,4 @@ rm -rf .xwin-cache /bin/xwin
 rustup target add x86_64-pc-windows-msvc
 
 # jerry rig llvm
-ln -s llvm-ar /usr/bin/llvm-dlltool
 rm /usr/bin/llvm-config # will be replaced with script


### PR DESCRIPTION
- feat: switch to multiple split docker images
- update CI to build seperate images
- update rust
- fix cargo build
- fix clippy image
- always provide llvm-dlltool
